### PR TITLE
リンクの文字抽出に失敗する不具合を修正

### DIFF
--- a/jquery.markdown.js
+++ b/jquery.markdown.js
@@ -491,9 +491,9 @@
                                         }
 
                                         if (null !== md.vs.nowv.match(/!?\[.*\]\(.*\)/)) {
-                                            var alt = md.vs.nowv.replace(/^.*?!?\[(.*)\]\(.*\)/, "$1");
-                                            var src = md.vs.nowv.replace(/^.*?!?\[.*\]\((.*)\)/, "$1").split(" ")[0];
-                                            var title = md.vs.nowv.replace(/^.*?!?\[.*\]\(.*\s"(.*)"\)/, "$1");
+                                            var alt = md.vs.nowv.replace(/^.*?!?\[(.*)\]\(.*\).*/, "$1");
+                                            var src = md.vs.nowv.replace(/^.*?!?\[.*\]\((.*)\).*/, "$1").split(" ")[0];
+                                            var title = md.vs.nowv.replace(/^.*?!?\[.*\]\(.*\s"(.*)"\).*/, "$1");
                                             title = (md.vs.nowv !== title) ? title : null;
 
                                             var a = createtags(src, alt, title);


### PR DESCRIPTION
リンクの後方に文字列が続く場合、その文字列もリンクの `alt` 属性になってしまう不具合を修正しました。

不具合の例として、単独の `[Test](#test)` は正しくタグが生成されますが、`[Test](#test) is a link.` のようにリンクマークアップの直後にも文字列が続く場合、`<a href="#test">Test is a link.</a>
is a link.` のようにタグが生成されてしまいます。

`alt`、`src`、`title`の各文字を抽出するとき、前方だけでなく後方の無関係な文字も除外するように修正しました。