### PR TITLE
リンクの文字列抽出に関する不具合を修正

### DIFF
--- a/jquery.markdown.js
+++ b/jquery.markdown.js
@@ -501,14 +501,15 @@
                                         }
 
                                         if (null !== md.vs.nowv.match(/!?\[.*?\]\[.*?\]/)) {
-                                            var alt = md.vs.nowv.replace(/!?\[(.*?)\]\[.*?\]/, "$1");
-                                            var src = md.vs.nowv.replace(/!?\[.*?\]\[(.*?)\]/, "$1");
+                                            var alt = md.vs.nowv.replace(/^.*?!?\[(.*?)\]\[.*?\].*/, "$1");
+                                            var src = md.vs.nowv.replace(/^.*?!?\[.*?\]\[(.*?)\].*/, "$1");
 
                                             var title_matches = getTitle(src);
                                             src   = title_matches[0];
                                             title = title_matches[1];
 
-                                            md.vs.nowv = createtags(src, alt, title);
+                                            var a = createtags(src, alt, title);
+                                            md.vs.nowv = md.vs.nowv.replace(/^(.*)?(!?\[.*?\]\[.*?\])(.*)?/, "$1" + a + "$3");
                                         }
 
                                         if (null !== md.vs.nowv.match(/!?\[.*?\]/)) {

--- a/jquery.markdown.js
+++ b/jquery.markdown.js
@@ -490,19 +490,19 @@
                                             return a;
                                         }
 
-                                        if (null !== md.vs.nowv.match(/!?\[.*\]\(.*\)/)) {
-                                            var alt = md.vs.nowv.replace(/^.*?!?\[(.*)\]\(.*\).*/, "$1");
-                                            var src = md.vs.nowv.replace(/^.*?!?\[.*\]\((.*)\).*/, "$1").split(" ")[0];
-                                            var title = md.vs.nowv.replace(/^.*?!?\[.*\]\(.*\s"(.*)"\).*/, "$1");
+                                        if (null !== md.vs.nowv.match(/!?\[.*?\]\(.*?\)/)) {
+                                            var alt = md.vs.nowv.replace(/^.*?!?\[(.*?)\]\(.*?\).*/, "$1");
+                                            var src = md.vs.nowv.replace(/^.*?!?\[.*?\]\((.*?)\).*/, "$1").split(" ")[0];
+                                            var title = md.vs.nowv.replace(/^.*?!?\[.*?\]\(.*\s"(.*?)"\).*/, "$1");
                                             title = (md.vs.nowv !== title) ? title : null;
 
                                             var a = createtags(src, alt, title);
-                                            md.vs.nowv = md.vs.nowv.replace(/^(.*)?(!?\[.*\]\(.*\))(.*)?/, "$1" + a + "$3");
+                                            md.vs.nowv = md.vs.nowv.replace(/^(.*)?(!?\[.*?\]\(.*?\))(.*)?/, "$1" + a + "$3");
                                         }
 
-                                        if (null !== md.vs.nowv.match(/!?\[.*\]\[.*\]/)) {
-                                            var alt = md.vs.nowv.replace(/!?\[(.*)\]\[.*\]/, "$1");
-                                            var src = md.vs.nowv.replace(/!?\[.*\]\[(.*)\]/, "$1");
+                                        if (null !== md.vs.nowv.match(/!?\[.*?\]\[.*?\]/)) {
+                                            var alt = md.vs.nowv.replace(/!?\[(.*?)\]\[.*?\]/, "$1");
+                                            var src = md.vs.nowv.replace(/!?\[.*?\]\[(.*?)\]/, "$1");
 
                                             var title_matches = getTitle(src);
                                             src   = title_matches[0];
@@ -511,15 +511,15 @@
                                             md.vs.nowv = createtags(src, alt, title);
                                         }
 
-                                        if (null !== md.vs.nowv.match(/!?\[.*\]/)) {
-                                            var alt = src = md.vs.nowv.replace(/^.*?!?\[(.*)\].*?/, "$1");
+                                        if (null !== md.vs.nowv.match(/!?\[.*?\]/)) {
+                                            var alt = src = md.vs.nowv.replace(/^.*?!?\[(.*?)\].*?/, "$1");
 
                                             var title_matches = getTitle(src);
                                             src   = title_matches[0];
                                             title = title_matches[1];
 
                                             var a = createtags(src, alt, title);
-                                            md.vs.nowv = md.vs.nowv.replace(/^(.*)?!?\[(.*)\](.*)?/, "$1" + a + "$3");
+                                            md.vs.nowv = md.vs.nowv.replace(/^(.*)?!?\[(.*?)\](.*)?/, "$1" + a + "$3");
                                         }
 
                                         if (typeof md.vs.nexv !== 'undefined') {


### PR DESCRIPTION
使用中に2つほど気になった点があったためPRしました。

1つ目、リンクの文字列抽出で `.*` を使っていますが、これは最長一致のため、リンクの後に続く括弧にも誤ってマッチしてしまいます。これを最短一致 `.*?` に修正しました。

具体的には、

```
[リンクテキスト](#リンクアドレス "リンクタイトル") 通常のテキストです (括弧)`
```

という入力に対して、

```
<a target="_blank" title="リンクタイトル" href="#リンクアドレス">リンクテキスト</a> 通常のテキストです (括弧)
```

と出力されるべきと思いますが、現状では以下のように出力されてしまいます。

```
<a target="_blank" title="リンクタイトル 通常のテキストです (括弧)" href="#リンクアドレス">リンクテキスト</a>
```

---

2つ目、参照リンクの前後の文字列が消えてしまうようです。
通常のリンクと同様に置換を行うように修正しました。
